### PR TITLE
Add user input serialization and input validation

### DIFF
--- a/smart_shala/lib/models/testdetailsmodel.dart
+++ b/smart_shala/lib/models/testdetailsmodel.dart
@@ -1,0 +1,34 @@
+// Serializable model to hold the test details
+
+class TestDetailsModel {
+  final String name;
+  final String desc;
+  final int year;
+  final String sec;
+  final String topic;
+
+  const TestDetailsModel({
+    required this.name,
+    required this.desc,
+    required this.year,
+    required this.sec,
+    required this.topic,
+  });
+
+  factory TestDetailsModel.fromJson(Map<String, dynamic> json) {
+    return TestDetailsModel(
+        name: json['name'] as String,
+        desc: json['desc'] as String,
+        year: json['year'] as int,
+        sec: json['sec'] as String,
+        topic: json['topic'] as String);
+  }
+  
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'desc': desc,
+    'year': year,
+    'sec': sec,
+    'topic': topic,
+  };
+}

--- a/smart_shala/lib/test_creation.dart
+++ b/smart_shala/lib/test_creation.dart
@@ -52,7 +52,9 @@ class _TestOptionsState extends State<TestOptions> {
 /// class to build a scrollable listview on-demand
 
 class TestCreationPage extends StatefulWidget {
-  const TestCreationPage({Key? key}) : super(key: key);
+  final int totalQuestions;
+  const TestCreationPage({Key? key, required this.totalQuestions})
+      : super(key: key);
 
   @override
   State<TestCreationPage> createState() => _TestCreationPageState();
@@ -66,9 +68,11 @@ class _TestCreationPageState extends State<TestCreationPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Create Test')),
+      floatingActionButton:
+          FloatingActionButton(onPressed: () {}, child: const Icon(Icons.send)),
       body: ListView.builder(
           // TODO: Get the question number from the previous page
-          itemCount: 30,
+          itemCount: widget.totalQuestions,
           itemBuilder: (context, index) {
             return Column(children: [
               TestOptions(questionnum: index + 1),


### PR DESCRIPTION
feat: 
 - save user input in text controllers
 - add details model that convert user input to json
 - add input validation
 - add button onpress logic
 - render question number according to number added in question number
   field in test details page

chore:
 - remove image upload button

todo:
 - write api post logic
 - write input retention for test options
 - change test creation page ui and add required fields

deprecate:
 - image_picker dependency